### PR TITLE
Fix bug of computer precision in tsearch

### DIFF
--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -85,10 +85,10 @@ QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double
 {
   int n = x.size();
   
-  double xmin(std::numeric_limits<double>::max());
-  double ymin(std::numeric_limits<double>::max());
-  double xmax(std::numeric_limits<double>::min());
-  double ymax(std::numeric_limits<double>::min());
+  double xmin = x[0];
+  double ymin = y[0];
+  double xmax = x[0];
+  double ymax = y[0];
   
   for(int i = 0 ; i < n ; i++)
   {

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -66,7 +66,19 @@ bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary)
 //' @importFrom Rcpp sourceCpp
 // [[Rcpp::export]]
 SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVector xi, NumericVector yi, bool bary = false)
-{
+{  
+  // Shift the point cloud to the origin to avoid computer precision error
+  // The shift is done by reference to save memory. The original data is shift back at the end
+  
+  double minx = min(x);
+  double miny = min(y);
+  x = x - minx;
+  y = y - miny;
+  xi = xi - minx;
+  yi = yi - miny;
+
+  // Algorithm
+  
   QuadTree *tree = QuadTree::create(as< std::vector<double> >(xi),as< std::vector<double> >(yi));
 
   int nelem = elem.nrow();
@@ -143,6 +155,12 @@ SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVec
   }
 
   delete tree;
+  
+  // Shift back the data
+  x = x + minx;
+  y = y + miny;
+  xi = xi + minx;
+  yi = yi + miny;
   
   if (bary)
   {

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -42,13 +42,13 @@ static inline double min (double a, double b, double c)
 
 bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary)
 {
-    double s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
-    double t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
+    float s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
+    float t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
 
     if ((s <= 0) != (t <= 0))
         return false;
 
-    double  A = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
+    float  A = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
 
     if (A < 0)
     {

--- a/pkg/tests/testthat/test-tsearch.R
+++ b/pkg/tests/testthat/test-tsearch.R
@@ -21,3 +21,36 @@ test_that("tsearch gives the expected output", {
   expect_true(is.na(ts))
 })
 
+test_that("tsearch gives the expected output when computer precision problem arise", {
+  x <- c(6.89, 7.15, 7.03)
+  y <- c(7.76, 7.75, 8.35)
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(x, y, tri, 7.125, 7.875)
+  expect_that(ts, equals(1))
+  
+  x <- c(278287.03, 278286.89, 278287.15)
+  y <- c(602248.35, 602247.76, 602247.75)
+  
+  tri = matrix(c(1,2,3), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(3,2,1), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  tri = matrix(c(2,3,1), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(2,1,3), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(3,1,2), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+})


### PR DESCRIPTION
Hi David,

This PR solve some bugs. I spent the entire day on this issue, it drove me crazy ! It was so complex to figure out what was the problem. So I must explain what I did and why I did it.

Changes in `QuadTree.cpp` correspond to nothing serious. The bug occurs when we search for a single point and probably in other cases but I spend to much time on the second bug and I don't really remember what was the problem.

The second bug, corrected in `Rtsearch.cpp` is basically the same problem than reported with `delaunayn` in #12 and #11. It is a problem of computer precision. This bug was present in the former version of the function too. 

I use a lot `tsearch` to rasterize the delaunay triangulation and I found some empty pixels not interpolated in my rasters. This happens when the searched point is very close to the edge of a triangle and the coordinates of the points are relatively large. In this case the accuracy of the barycentric coordinates and the triangle area are not accurate. Depending on the order of the points in the Delaunay matrix the function `PointInTriangle` can return both true or false. For example if the points of the triangles are in the order A B C the function return true while in the order B C A in return false because the measured areas are respectively 0.1485 and 0.1483 instead of 0.1484 (the true measure).

Therefore sometime the `tsearch` function fail to find the id of the triangle despite the fact that the point is in the triangle. It can occurs more or less randomly since the order of the point in the delaunay matrix depends on how the triangulation started. Indeed, removing one point from the original data can lead to the same triangulation but with some triangle described in another order. This minor change is sufficient to get a different result.

The solution was actually yours. I shifted the inputs to the origin (0,0). A rescaling can be done as well. In other words the `tsearch` function needs the same options than `delaunayn`. Here the `QbB` option.  

The implementation is a little bit tricky and need explanations. I have a lot of concern regarding memory usage since the implementation using QuadTree has been done to speed-up the function when used with a lot of points. Moreover the QuadTree implementation already use much more memory than the former implementation. Therefore I was not keen to create new variables to store the shifted coordinates. So, I update the original data by reference using a pointer on the user's data. That means that the user's R environment is temporarily modified since I modify the data in place. Then, I shift back the original data. This is transparent for the user.

If you're not conformable with that you can simply make a copy.

I think the shift is safe like the `QbB`option... That means *I hope it's safe*

JR

