### PR TITLE
 Testing whether a quantity is zero

### DIFF
--- a/pkg/R/RcppExports.R
+++ b/pkg/R/RcppExports.R
@@ -2,7 +2,7 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 #' @importFrom Rcpp sourceCpp
-C_tsearch <- function(x, y, elem, xi, yi, bary = FALSE) {
-    .Call('geometry_C_tsearch', PACKAGE = 'geometry', x, y, elem, xi, yi, bary)
+C_tsearch <- function(x, y, elem, xi, yi, bary = FALSE, eps = 1.0e-12) {
+    .Call('_geometry_C_tsearch', PACKAGE = 'geometry', x, y, elem, xi, yi, bary, eps)
 }
 

--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -85,10 +85,10 @@ QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double
 {
   int n = x.size();
   
-  double xmin(std::numeric_limits<double>::max());
-  double ymin(std::numeric_limits<double>::max());
-  double xmax(std::numeric_limits<double>::min());
-  double ymax(std::numeric_limits<double>::min());
+  double xmin = x[0];
+  double ymin = y[0];
+  double xmax = x[0];
+  double ymax = y[0];
   
   for(int i = 0 ; i < n ; i++)
   {

--- a/pkg/src/RcppExports.cpp
+++ b/pkg/src/RcppExports.cpp
@@ -6,8 +6,8 @@
 using namespace Rcpp;
 
 // C_tsearch
-SEXP C_tsearch(NumericVector x, NumericVector y, IntegerMatrix elem, NumericVector xi, NumericVector yi, bool bary);
-RcppExport SEXP geometry_C_tsearch(SEXP xSEXP, SEXP ySEXP, SEXP elemSEXP, SEXP xiSEXP, SEXP yiSEXP, SEXP barySEXP) {
+SEXP C_tsearch(NumericVector x, NumericVector y, IntegerMatrix elem, NumericVector xi, NumericVector yi, bool bary, double eps);
+RcppExport SEXP _geometry_C_tsearch(SEXP xSEXP, SEXP ySEXP, SEXP elemSEXP, SEXP xiSEXP, SEXP yiSEXP, SEXP barySEXP, SEXP epsSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -17,7 +17,8 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< NumericVector >::type xi(xiSEXP);
     Rcpp::traits::input_parameter< NumericVector >::type yi(yiSEXP);
     Rcpp::traits::input_parameter< bool >::type bary(barySEXP);
-    rcpp_result_gen = Rcpp::wrap(C_tsearch(x, y, elem, xi, yi, bary));
+    Rcpp::traits::input_parameter< double >::type eps(epsSEXP);
+    rcpp_result_gen = Rcpp::wrap(C_tsearch(x, y, elem, xi, yi, bary, eps));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -66,7 +66,19 @@ bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary)
 //' @importFrom Rcpp sourceCpp
 // [[Rcpp::export]]
 SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVector xi, NumericVector yi, bool bary = false)
-{
+{  
+  // Shift the point cloud to the origin to avoid computer precision error
+  // The shift is done by reference to save memory. The original data is shift back at the end
+  
+  double minx = min(x);
+  double miny = min(y);
+  x = x - minx;
+  y = y - miny;
+  xi = xi - minx;
+  yi = yi - miny;
+
+  // Algorithm
+  
   QuadTree *tree = QuadTree::create(as< std::vector<double> >(xi),as< std::vector<double> >(yi));
 
   int nelem = elem.nrow();
@@ -143,6 +155,12 @@ SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVec
   }
 
   delete tree;
+  
+  // Shift back the data
+  x = x + minx;
+  y = y + miny;
+  xi = xi + minx;
+  yi = yi + miny;
   
   if (bary)
   {

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -71,8 +71,6 @@ bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary, double 
   bary->x = c;
   bary->y = b;
   
-  Rcout << (-eps <= a && a <= 1+eps && -eps <= b && b <= 1+eps && -eps <= c && c <= 1+eps) << std::endl;
-  
   return -eps <= a && a <= 1+eps && -eps <= b && b <= 1+eps && -eps <= c && c <= 1+eps;
 }
 

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -41,26 +41,6 @@ static inline double min (double a, double b, double c)
     return (a > c ? c : a);
 }
 
-double distanceSquarePointToSegment(const Point& p1, const Point& p2, const Point& p)
-{
-  double p1_p2_squareLength = (p2.x - p1.x)*(p2.x - p1.x) + (p2.y - p1.y)*(p2.y - p1.y);
-  double dotProduct = ((p.x - p1.x)*(p2.x - p1.x) + (p.y - p1.y)*(p2.y - p1.y)) / p1_p2_squareLength;
-  
-  if ( dotProduct < 0 )
-  {
-    return (p.x - p1.x)*(p.x - p1.x) + (p.y - p1.y)*(p.y - p1.y);
-  }
-  else if ( dotProduct <= 1 )
-  {
-    double p_p1_squareLength = (p1.x - p.x)*(p1.x - p.x) + (p1.y - p.y)*(p1.y - p.y);
-    return p_p1_squareLength - dotProduct * dotProduct * p1_p2_squareLength;
-  }
-  else
-  {
-    return (p.x - p2.x)*(p.x - p2.x) + (p.y - p2.y)*(p.y - p2.y);
-  }
-}
-
 bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary, double eps)
 {
   double det = ((p1.y - p2.y)*(p0.x - p2.x) + (p2.x - p1.x)*(p0.y - p2.y));

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -42,13 +42,13 @@ static inline double min (double a, double b, double c)
 
 bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary)
 {
-    double s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
-    double t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
+    float s = p0.y * p2.x - p0.x * p2.y + (p2.y - p0.y) * p.x + (p0.x - p2.x) * p.y;
+    float t = p0.x * p1.y - p0.y * p1.x + (p0.y - p1.y) * p.x + (p1.x - p0.x) * p.y;
 
     if ((s <= 0) != (t <= 0))
         return false;
 
-    double  A = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
+    float  A = -p1.y * p2.x + p0.y * (p2.x - p1.x) + p0.x * (p1.y - p2.y) + p1.x * p2.y;
 
     if (A < 0)
     {

--- a/pkg/src/geometry_init.c
+++ b/pkg/src/geometry_init.c
@@ -11,13 +11,13 @@
 extern SEXP C_convhulln(SEXP, SEXP, SEXP);
 extern SEXP C_delaunayn(SEXP, SEXP, SEXP);
 extern SEXP C_inhulln(SEXP, SEXP);
-extern SEXP geometry_C_tsearch(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+extern SEXP _geometry_C_tsearch(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 
 static const R_CallMethodDef CallEntries[] = {
-    {"C_convhulln", (DL_FUNC) &C_convhulln, 3},
-    {"C_delaunayn", (DL_FUNC) &C_delaunayn, 3},
-    {"C_inhulln",   (DL_FUNC) &C_inhulln,   2},
-    {"geometry_C_tsearch",   (DL_FUNC) &geometry_C_tsearch,   6},
+    {"C_convhulln",           (DL_FUNC) &C_convhulln,         3},
+    {"C_delaunayn",           (DL_FUNC) &C_delaunayn,         3},
+    {"C_inhulln",             (DL_FUNC) &C_inhulln,           2},
+    {"_geometry_C_tsearch",   (DL_FUNC) &_geometry_C_tsearch, 7},
     {NULL, NULL, 0}
 };
 

--- a/pkg/tests/testthat/test-tsearch.R
+++ b/pkg/tests/testthat/test-tsearch.R
@@ -22,35 +22,82 @@ test_that("tsearch gives the expected output", {
 })
 
 test_that("tsearch gives the expected output when computer precision problem arise", {
+  
+  # ==== Hand made test ====
+  
+  x1 <- 1/10
+  y1 <- 1/9
+  x2 <- 100/8
+  y2 <- 100/3
+  P <- rbind(c(x1, y1),  c(x2, y2),  c(100/4, 100/9), c(-100/8, 100/6))
+  
+  # And a single point p(x, y) lying exactly on the segment [p1, p2] :
+  xi <- x1 + (3/7)*(x2 - x1)
+  yi <- y1 + (3/7)*(y2 - y1)
+  
+  # Should always give triangle 2 since this is the lastest tested
+  
+  tri1 <- rbind(1:3, c(1, 2, 4))
+  ts <- tsearch(P[,1], P[,2], tri1, xi, yi)
+  expect_equal(ts, 2)
+  
+  tri2 <- rbind(c(1, 2, 4), 1:3)
+  ts <- tsearch(P[,1], P[,2], tri2, xi, yi)
+  expect_equal(ts, 2)
+  
+  # The same but with only one triangle
+  P <- rbind(c(x1, y1),  c(x2, y2),  c(100/4, 100/9))
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(P[,1], P[,2], tri, xi, yi)
+  expect_that(ts, equals(1))
+  
+  tri <- matrix(c(3, 2, 1), 1, 3)
+  ts <- tsearch(P[,1], P[,2], tri, xi, yi)
+  expect_that(ts, equals(1))
+  
+  # The same but with the other triangle
+  P <- rbind(c(x2, y2),  c(100/4, 100/9), c(-100/8, 100/6))
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(P[,1], P[,2], tri, xi, yi)
+  expect_that(ts, equals(1))
+  
+  tri <- matrix(c(3, 2, 1), 1, 3)
+  ts <- tsearch(P[,1], P[,2], tri, xi, yi)
+  expect_that(ts, equals(1))
+  
+  # Another test
   x <- c(6.89, 7.15, 7.03)
   y <- c(7.76, 7.75, 8.35)
   tri <- matrix(c(1, 2, 3), 1, 3)
   ts <- tsearch(x, y, tri, 7.125, 7.875)
   expect_that(ts, equals(1))
   
-  x <- c(278287.03, 278286.89, 278287.15)
-  y <- c(602248.35, 602247.76, 602247.75)
+  # ==== Test known to bug in former code ====
   
-  tri = matrix(c(1,2,3), 1,3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  x <- c(278287.03, 278286.89, 278287.15, 278287.3)
+  y <- c(602248.35, 602247.76, 602247.75, 602248.35)
+  
+  xi = 278287.125
+  yi = 602247.875  
+  
+  # Should always give triangle 2 but here it does not work
+  
+  tri = rbind(c(3,1,4), c(3,1,2))
+  ts <- tsearch(x, y, tri, xi, yi)
+  expect_that(ts, equals(2))
+  
+  tri = rbind(c(1,2,3), c(1,3,4))
+  ts <- tsearch(x, y, tri, xi, yi)
   expect_that(ts, equals(1))
   
-  tri = matrix(c(3,2,1), 1,3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
-  expect_that(ts, equals(1))
-  tri = matrix(c(2,3,1), 1,3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
-  expect_that(ts, equals(1))
+  # This is because the buffer epsilon is 1.0e-12.
   
-  tri = matrix(c(2,1,3), 1,3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
-  expect_that(ts, equals(1))
-  
-  tri = matrix(c(3,1,2), 1,3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
-  expect_that(ts, equals(1))
+  x <- c(278287.03, 278287.15, 278287.3)
+  y <- c(602248.35, 602247.75, 602248.35)
   
   tri <- matrix(c(1, 2, 3), 1, 3)
-  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
-  expect_that(ts, equals(1))
+  ts <- tsearch(x, y, tri, xi, yi)
+  expect_true(is.na(ts))
+  
+  #expect_that(ts, equals(1)))  #With epsilon = 1.0e-10 it works.
 })

--- a/pkg/tests/testthat/test-tsearch.R
+++ b/pkg/tests/testthat/test-tsearch.R
@@ -21,3 +21,36 @@ test_that("tsearch gives the expected output", {
   expect_true(is.na(ts))
 })
 
+test_that("tsearch gives the expected output when computer precision problem arise", {
+  x <- c(6.89, 7.15, 7.03)
+  y <- c(7.76, 7.75, 8.35)
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(x, y, tri, 7.125, 7.875)
+  expect_that(ts, equals(1))
+  
+  x <- c(278287.03, 278286.89, 278287.15)
+  y <- c(602248.35, 602247.76, 602247.75)
+  
+  tri = matrix(c(1,2,3), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(3,2,1), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  tri = matrix(c(2,3,1), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(2,1,3), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri = matrix(c(3,1,2), 1,3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+  
+  tri <- matrix(c(1, 2, 3), 1, 3)
+  ts <- tsearch(x, y, tri, 278287.125, 602247.875)
+  expect_that(ts, equals(1))
+})


### PR DESCRIPTION
This new code should be almost the exact same computation method than the previous release. The only interesting commit is 7f0bd49

The `deldir` package has a parameter `eps` to test  whether a quantity is zero or not. It is set at `1.0e-9` by default. In octave this is hard coded and fixed to `1.0e-12`. I did the same. This explains the test results lines 83-102 in `test-tsearch.R` .

This is your choice to add or not a parameter `eps`. So far it should work like the previous release.

Btw, please ensure you have the lastest `Rcpp` version. The names of the automatic exports changed with the latest release. 