### PR TITLE
Cross link functions in docs

### DIFF
--- a/pkg/R/cart2pol.R
+++ b/pkg/R/cart2pol.R
@@ -30,7 +30,8 @@
 ##' @return A matrix \code{P} where each row represents one
 ##'   polar/(cylindrical) coordinate (\code{theta}, \code{r}, (,
 ##'   \code{z})).
-##' @seealso pol2cart, cart2sph, sph2cart
+##' @seealso \code{\link{pol2cart}}, \code{\link{cart2sph}},
+##'   \code{\link{sph2cart}}
 ##' @author Kai Habel
 ##' @author David Sterratt
 ##' @export

--- a/pkg/R/cart2sph.R
+++ b/pkg/R/cart2sph.R
@@ -29,7 +29,8 @@
 ##' \item{\code{theta}}{the angle relative to the positive x-axis}
 ##' \item{\code{phi}}{the angle relative to the xy-plane}
 ##' \item{\code{r}}{the distance to the origin \code{(0, 0, 0)}}
-##' @seealso sph2cart, cart2pol, pol2cart
+##' @seealso \code{\link{sph2cart}}, \code{\link{cart2pol}},
+##'   \code{\link{pol2cart}}
 ##' @author Kai Habel
 ##' @author David Sterratt
 ##' @export

--- a/pkg/R/convhulln.R
+++ b/pkg/R/convhulln.R
@@ -57,7 +57,7 @@
 ##' See further notes in \code{\link{delaunayn}}.
 ##' 
 ##' @author Raoul Grasman, Robert B. Gramacy, Pavlo Mozharovskyi and David Sterratt
-##' \email{david.c.sterratt@ed.ac.uk}
+##' \email{david.c.sterratt@@ed.ac.uk}
 ##' @seealso \code{\link[tripack]{convex.hull}}, \code{\link{delaunayn}},
 ##' \code{\link{surf.tri}}, \code{\link{distmesh2d}}, \code{\link{intersectn}}
 ##' @references \cite{Barber, C.B., Dobkin, D.P., and Huhdanpaa, H.T.,
@@ -84,8 +84,8 @@ convhulln <- function (p, options = "Tv", output.options=NULL, return.non.triang
   tmpdir <- tempdir()
   ## R should guarantee the tmpdir is writable, but check in any case
   if (file.access(tmpdir, 2) == -1) {
-    stop(paste("Unable to write to R temporary directory", tmpdir, "\n",
-               "Try setting the permissions on this directory so it is writable."))
+    stop("Unable to write to R temporary directory ", tmpdir, "\n",
+         "Try setting the permissions on this directory so it is writable.")
   }
   
   ## Combine and check options

--- a/pkg/R/delaunayn.R
+++ b/pkg/R/delaunayn.R
@@ -110,8 +110,8 @@ function(p, options=NULL, output.options=NULL, full=FALSE) {
   tmpdir <- tempdir()
   ## R should guarantee the tmpdir is writable, but check in any case
   if (file.access(tmpdir, 2) == -1) {
-    stop(paste("Unable to write to R temporary directory", tmpdir, "\n",
-               "Try setting the permissions on this directory so it is writable."))
+    stop("Unable to write to R temporary directory ", tmpdir, "\n",
+         "Try setting the permissions on this directory so it is writable.")
   }
 
   ## Coerce the input to be matrix

--- a/pkg/R/distmesh2d.R
+++ b/pkg/R/distmesh2d.R
@@ -59,9 +59,9 @@
 ##' @param plot logical.  If \code{TRUE} (default), the mesh is
 ##'   plotted as it is generated.
 ##' @return \code{n}-by-\code{2} matrix with node positions.
-##' @section Wishlist : \itemize{ \item*Implement in C/Fortran
-##'   \item*Implement an \code{n}D version as provided in the Matlab
-##'   package \item*Translate other functions of the Matlab package }
+##' @section Wishlist : \itemize{ \item Implement in C/Fortran
+##'   \item Implement an \code{n}D version as provided in the Matlab
+##'   package \item Translate other functions of the Matlab package }
 ##' @author Raoul Grasman
 ##' @seealso \code{\link[tripack]{tri.mesh}}, \code{\link{delaunayn}},
 ##'   \code{\link{mesh.dcircle}}, \code{\link{mesh.drectangle}},

--- a/pkg/R/distmeshnd.R
+++ b/pkg/R/distmeshnd.R
@@ -52,7 +52,7 @@
 ##' @param deps Stepsize \eqn{\Delta x} in numerical derivative computation for
 ##' distance function.
 ##' @return \code{m}-by-\code{n} matrix with node positions.
-##' @section Wishlist : \itemize{ \item*Implement in C/Fortran \item*Translate
+##' @section Wishlist : \itemize{ \item Implement in C/Fortran \item Translate
 ##' other functions of the Matlab package }
 ##' @author Raoul Grasman; translated from original Matlab sources of Per-Olof
 ##' Persson.

--- a/pkg/R/entry.value.R
+++ b/pkg/R/entry.value.R
@@ -29,30 +29,26 @@
 function (a, idx) 
 {
     if (!is.array(a)) 
-        stop(paste("First argument `", deparse(substitute(a)), 
-            "' should be an array.", sep = ""))
+        stop("First argument `", deparse(substitute(a)), "' should be an array.")
     if (!is.matrix(idx)) 
-        stop(paste("Second argument `", substitute(idx), "' should be a matrix.", 
-            sep = ""))
+        stop("Second argument `", substitute(idx), "' should be a matrix.")
     n <- length(dim(a))
     if (n != ncol(idx)) 
-        stop(paste("Number of columns in", deparse(substitute(idx)), 
-            "is incompatible is dimension of", deparse(substitute(a))))
+        stop("Number of columns in", deparse(substitute(idx)),
+             "is incompatible is dimension of", deparse(substitute(a)))
     a[(idx - 1) %*% c(1, cumprod(dim(a))[-n]) + 1]
 }
 "entry.value<-" <-
 function (a, idx, value) 
 {
     if (!is.array(a)) 
-        stop(paste("First argument `", deparse(substitute(a)), 
-            "' should be an array.", sep = ""))
+        stop("First argument `", deparse(substitute(a)), "' should be an array.")
     if (!is.matrix(idx)) 
-        stop(paste("Second argument `", substitute(idx), "' should be a matrix.", 
-            sep = ""))
+        stop("Second argument `", substitute(idx), "' should be a matrix.")
     n <- length(dim(a))
     if (n != ncol(idx)) 
-        stop(paste("Number of columns in", deparse(substitute(idx)), 
-            "is incompatible is dimension of", deparse(substitute(a))))
+        stop("Number of columns in", deparse(substitute(idx)),
+            "is incompatible is dimension of", deparse(substitute(a)))
     a[(idx - 1) %*% c(1, cumprod(dim(a))[-n]) + 1] <- value
     return(a)
 }

--- a/pkg/R/extprod3d.R
+++ b/pkg/R/extprod3d.R
@@ -17,7 +17,7 @@
 ##'   \code{drop} is \code{TRUE}, a vector of length 3.
 ##' @author Raoul Grasman
 ##' @keywords arith math array
-##' @seealso drop
+##' @seealso \code{\link[base]{drop}}
 ##' @export
 "extprod3d" <-
 function (x, y, drop=TRUE) 

--- a/pkg/R/halfspacen.R
+++ b/pkg/R/halfspacen.R
@@ -58,7 +58,7 @@ halfspacen <- function (p, fp, options = "Tv") {
 
   ## Check dimensions
   if (ncol(p) - 1 != length(as.vector(fp))) {
-    stop(paste("Dimension of hyperspace is", ncol(p) - 1, "but dimension of fixed point is", length(as.vector(fp))))
+    stop("Dimension of hyperspace is ", ncol(p) - 1, " but dimension of fixed point is ", length(as.vector(fp)))
   }
   
 

--- a/pkg/R/halfspacen.R
+++ b/pkg/R/halfspacen.R
@@ -35,8 +35,8 @@ halfspacen <- function (p, fp, options = "Tv") {
   tmpdir <- tempdir()
   ## R should guarantee the tmpdir is writable, but check in any case
   if (file.access(tmpdir, 2) == -1) {
-    stop(paste("Unable to write to R temporary directory", tmpdir, "\n",
-               "Try setting the permissions on this directory so it is writable."))
+    stop("Unable to write to R temporary directory ", tmpdir, "\n",
+         "Try setting the permissions on this directory so it is writable.")
   }
   
   ## Input sanitisation

--- a/pkg/R/inhulln.R
+++ b/pkg/R/inhulln.R
@@ -10,7 +10,7 @@
 ##' The rows of \code{p} represent \eqn{M} points in \eqn{N}-dimensional space.
 ##' @return A boolean vector with \eqn{M} elements
 ##' @author David Sterratt
-##' @seealso convhulln
+##' @seealso \code{\link{convhulln}}
 ##' @export
 ##' @examples
 ##' p <- cbind(c(-1, -1, 1), c(-1, 1, -1))

--- a/pkg/R/intersectn.R
+++ b/pkg/R/intersectn.R
@@ -21,9 +21,9 @@
 ##' ps1 <- rbox(0, C=0.5)
 ##' ps2 <- rbox(0, C=0.5) + 0.5
 ##' out <- intersectn(ps1, ps2)
-##' message(paste("Volume of 1st convex hull:", out$ch1$vol))
-##' message(paste("Volume of 2nd convex hull:", out$ch2$vol))
-##' message(paste("Volume of intersection convex hull:", out$ch$vol))
+##' message("Volume of 1st convex hull: ", out$ch1$vol)
+##' message("Volume of 2nd convex hull: ", out$ch2$vol)
+##' message("Volume of intersection convex hull: ", out$ch$vol)
 ##' @author David Sterratt
 ##' @seealso \code{\link{convhulln}}, \code{\link{halfspacen}},
 ##'   \code{\link{inhulln}}

--- a/pkg/R/intersectn.R
+++ b/pkg/R/intersectn.R
@@ -25,7 +25,8 @@
 ##' message(paste("Volume of 2nd convex hull:", out$ch2$vol))
 ##' message(paste("Volume of intersection convex hull:", out$ch$vol))
 ##' @author David Sterratt
-##' @seealso convhulln, halfspacen, inhulln
+##' @seealso \code{\link{convhulln}}, \code{\link{halfspacen}},
+##'   \code{\link{inhulln}}
 intersectn <- function(ps1, ps2, tol=0, return.chs=TRUE) {
   distinct <-
     any(apply(ps1, 2, min) > apply(ps2, 2, max)) ||

--- a/pkg/R/pol2cart.R
+++ b/pkg/R/pol2cart.R
@@ -30,7 +30,8 @@
 ##' @param z (optional) is the z-coordinate
 ##' @return a matrix \code{C} where each row represents one Cartesian
 ##'   coordinate (\code{x}, \code{y} (, \code{z})).
-##' @seealso cart2pol, sph2cart, cart2sph
+##' @seealso \code{\link{cart2pol}}, \code{\link{sph2cart}},
+##'   \code{\link{cart2sph}}
 ##' @author Kai Habel
 ##' @author David Sterratt
 ##' @export

--- a/pkg/R/sph2cart.R
+++ b/pkg/R/sph2cart.R
@@ -31,7 +31,7 @@
 ##' If only a single return argument is requested then return a matrix
 ##' \code{C} where each row represents one Cartesian coordinate
 ##' (\code{x}, \code{y}, \code{z}).
-##' @seealso cart2sph, pol2cart, cart2pol
+##' @seealso \code{\link{cart2sph}}, \code{\link{pol2cart}}, \code{\link{cart2pol}}
 ##' @author Kai Habel
 ##' @author David Sterratt
 ##' @export

--- a/pkg/R/tsearch.R
+++ b/pkg/R/tsearch.R
@@ -29,7 +29,7 @@
 ##' @author Jean-Romain Roussel (Quadtree algorithm), David Sterratt (Octave-based implementation)
 ##' @note The original Octave function is Copyright (C) 2007-2012
 ##'   David Bateman
-##' @seealso tsearchn, delaunayn
+##' @seealso \code{\link{tsearchn}}, \code{\link{delaunayn}}
 ##' @export
 tsearch <- function(x, y, t, xi, yi, bary=FALSE, method="quadtree") {
   xtxt  = deparse(substitute(x))
@@ -132,7 +132,7 @@ tsearch <- function(x, y, t, xi, yi, bary=FALSE, method="quadtree") {
 ##' @author David Sterratt
 ##' @note Based on the Octave function Copyright (C) 2007-2012 David
 ##'   Bateman.
-##' @seealso tsearch, delaunayn
+##' @seealso \code{\link{tsearch}}, \code{\link{delaunayn}}
 ##' @export
 tsearchn <- function(x, t, xi, ...) {
   if (any(is.na(x)) && inherits(t, "delaunayn")) {
@@ -253,7 +253,7 @@ tsearchn <- function(x, t, xi, ...) {
 ##' text(X[,1], X[,2], 1:3) # Label vertices
 ##' points(P)
 ##' cart2bary(X, P)
-##' @seealso bary2cart
+##' @seealso \code{\link{bary2cart}}
 ##' @export
 cart2bary <- function(X, P) {
   M <- nrow(P)
@@ -300,7 +300,7 @@ cart2bary <- function(X, P) {
 ##' text(X[,1], X[,2], 1:3) # Label vertices
 ##' P <- bary2cart(X, beta)
 ##' points(P)
-##' @seealso cart2bary
+##' @seealso \code{\link{cart2bary}}
 ##' @author David Sterratt
 ##' @export
 bary2cart <- function(X, Beta) {

--- a/pkg/man/bary2cart.Rd
+++ b/pkg/man/bary2cart.Rd
@@ -38,7 +38,7 @@ P <- bary2cart(X, beta)
 points(P)
 }
 \seealso{
-cart2bary
+\code{\link{cart2bary}}
 }
 \author{
 David Sterratt

--- a/pkg/man/cart2bary.Rd
+++ b/pkg/man/cart2bary.Rd
@@ -66,7 +66,7 @@ points(P)
 cart2bary(X, P)
 }
 \seealso{
-bary2cart
+\code{\link{bary2cart}}
 }
 \author{
 David Sterratt

--- a/pkg/man/cart2pol.Rd
+++ b/pkg/man/cart2pol.Rd
@@ -24,7 +24,8 @@ scalar.  If called with a single matrix argument then each row of \code{C}
 represents the Cartesian coordinate (\code{x}, \code{y} (, \code{z})).
 }
 \seealso{
-pol2cart, cart2sph, sph2cart
+\code{\link{pol2cart}}, \code{\link{cart2sph}},
+  \code{\link{sph2cart}}
 }
 \author{
 Kai Habel

--- a/pkg/man/cart2sph.Rd
+++ b/pkg/man/cart2sph.Rd
@@ -24,7 +24,8 @@ Matrix with columns:
 Transform Cartesian to spherical coordinates
 }
 \seealso{
-sph2cart, cart2pol, pol2cart
+\code{\link{sph2cart}}, \code{\link{cart2pol}},
+  \code{\link{pol2cart}}
 }
 \author{
 Kai Habel

--- a/pkg/man/distmesh2d.Rd
+++ b/pkg/man/distmesh2d.Rd
@@ -89,9 +89,9 @@ See the references below for all details. Also, see the comments in the
 source file.
 }
 \section{Wishlist }{
- \itemize{ \item*Implement in C/Fortran
-  \item*Implement an \code{n}D version as provided in the Matlab
-  package \item*Translate other functions of the Matlab package }
+ \itemize{ \item Implement in C/Fortran
+  \item Implement an \code{n}D version as provided in the Matlab
+  package \item Translate other functions of the Matlab package }
 }
 
 \examples{

--- a/pkg/man/distmeshnd.Rd
+++ b/pkg/man/distmeshnd.Rd
@@ -77,7 +77,7 @@ See the references below for all details. Also, see the comments in the
 source file of \code{distmesh2d}.
 }
 \section{Wishlist }{
- \itemize{ \item*Implement in C/Fortran \item*Translate
+ \itemize{ \item Implement in C/Fortran \item Translate
 other functions of the Matlab package }
 }
 

--- a/pkg/man/extprod3d.Rd
+++ b/pkg/man/extprod3d.Rd
@@ -28,7 +28,7 @@ x1 * y2 - x2 * y1) }\deqn{ }{ (x2 * y3 - x3 * y2, x3 * y1 - x1 * y3, x1 *
 y2 - x2 * y1) } of the 3D vectors in \bold{x} and \bold{y}.
 }
 \seealso{
-drop
+\code{\link[base]{drop}}
 }
 \author{
 Raoul Grasman

--- a/pkg/man/inhulln.Rd
+++ b/pkg/man/inhulln.Rd
@@ -38,7 +38,7 @@ pin <- inhulln(ch, tp)
 pin == (tp[,1] < 1 & tp[,1] > -1)
 }
 \seealso{
-convhulln
+\code{\link{convhulln}}
 }
 \author{
 David Sterratt

--- a/pkg/man/intersectn.Rd
+++ b/pkg/man/intersectn.Rd
@@ -42,7 +42,8 @@ message(paste("Volume of 2nd convex hull:", out$ch2$vol))
 message(paste("Volume of intersection convex hull:", out$ch$vol))
 }
 \seealso{
-convhulln, halfspacen, inhulln
+\code{\link{convhulln}}, \code{\link{halfspacen}},
+  \code{\link{inhulln}}
 }
 \author{
 David Sterratt

--- a/pkg/man/intersectn.Rd
+++ b/pkg/man/intersectn.Rd
@@ -37,9 +37,9 @@ Compute convex hull of intersection of two sets of points
 ps1 <- rbox(0, C=0.5)
 ps2 <- rbox(0, C=0.5) + 0.5
 out <- intersectn(ps1, ps2)
-message(paste("Volume of 1st convex hull:", out$ch1$vol))
-message(paste("Volume of 2nd convex hull:", out$ch2$vol))
-message(paste("Volume of intersection convex hull:", out$ch$vol))
+message("Volume of 1st convex hull: ", out$ch1$vol)
+message("Volume of 2nd convex hull: ", out$ch2$vol)
+message("Volume of intersection convex hull: ", out$ch$vol)
 }
 \seealso{
 \code{\link{convhulln}}, \code{\link{halfspacen}},

--- a/pkg/man/pol2cart.Rd
+++ b/pkg/man/pol2cart.Rd
@@ -24,7 +24,8 @@ represents the polar/(cylindrical) coordinate (\code{theta}, \code{r}
 (, \code{z})).
 }
 \seealso{
-cart2pol, sph2cart, cart2sph
+\code{\link{cart2pol}}, \code{\link{sph2cart}},
+  \code{\link{cart2sph}}
 }
 \author{
 Kai Habel

--- a/pkg/man/sph2cart.Rd
+++ b/pkg/man/sph2cart.Rd
@@ -24,7 +24,7 @@ each row of \code{S} represents the spherical coordinate
 (\code{theta}, \code{phi}, \code{r}).
 }
 \seealso{
-cart2sph, pol2cart, cart2pol
+\code{\link{cart2sph}}, \code{\link{pol2cart}}, \code{\link{cart2pol}}
 }
 \author{
 Kai Habel

--- a/pkg/man/tsearch.Rd
+++ b/pkg/man/tsearch.Rd
@@ -48,7 +48,7 @@ The original Octave function is Copyright (C) 2007-2012
   David Bateman
 }
 \seealso{
-tsearchn, delaunayn
+\code{\link{tsearchn}}, \code{\link{delaunayn}}
 }
 \author{
 Jean-Romain Roussel (Quadtree algorithm), David Sterratt (Octave-based implementation)

--- a/pkg/man/tsearchn.Rd
+++ b/pkg/man/tsearchn.Rd
@@ -51,7 +51,7 @@ Based on the Octave function Copyright (C) 2007-2012 David
   Bateman.
 }
 \seealso{
-tsearch, delaunayn
+\code{\link{tsearch}}, \code{\link{delaunayn}}
 }
 \author{
 David Sterratt


### PR DESCRIPTION
Hi,

While reading `geometry` docs, I tried to visit the documentation of a function listed in "See Also" and noticed that some of them did not contain a link. This PR aims at fixing this. 

I also changed a couple of minor syntax issues (`@@` in email address, `\item ` for enumerations and removed `paste()` in `message()`).

I notice that my text editor also removed the trailing whitespaces. [Here](https://github.com/davidcsterratt/geometry/pull/32/files?w=1) is a link to the diff without taking these changes into account. Let me know if you prefer I reverted these changes.