### PR TITLE
Computer precision at quadtree edge (#39)

### DIFF
--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -147,7 +147,7 @@ bool QuadTree::insert(const Point& p)
 
 void QuadTree::subdivide()
 {
-  double esp = 0.0000001;
+  double esp = 1.0e-12;
   double half_res_half = boundary.half_res.x * 0.5;
   
   Point p(half_res_half + esp, half_res_half + esp);

--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -147,9 +147,10 @@ bool QuadTree::insert(const Point& p)
 
 void QuadTree::subdivide()
 {
+  double esp = 0.0000001;
   double half_res_half = boundary.half_res.x * 0.5;
   
-  Point p(half_res_half, half_res_half);
+  Point p(half_res_half + esp, half_res_half + esp);
   Point pNE(boundary.center.x + half_res_half, boundary.center.y + half_res_half);
   Point pNW(boundary.center.x - half_res_half, boundary.center.y + half_res_half);
   Point pSE(boundary.center.x + half_res_half, boundary.center.y - half_res_half);


### PR DESCRIPTION
TL;DR Fix #39 computer precision: I've fixed this issue a long time ago in my own code actually but my code  became very different from this one so I forgot that I fixed this issue :disappointed: 

---------

In the issue #39 the two problematic points that return `NA` belong exactly on the edge of a quad region +/- the computer precision. When the QuadTree searches in the quad regions, these points are found to be exterior to all the quad regions and are never extracted from the quadtree and thus not tested in `in_triangle()`.

The fix I used in my own code for several years now is to add an `epsilon` overlap between the quad region. I reproduce this fix here.