### PR TITLE
Computer precision #39

### DIFF
--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -27,12 +27,12 @@ Point::Point(const double x, const double y, const int id) : x(x), y(y), id(id) 
 BoundingBox::BoundingBox(){}
 BoundingBox::BoundingBox(const Point center, const Point half_res) : center(center), half_res(half_res) {}
 
-bool BoundingBox::contains(const Point& p)
+bool BoundingBox::contains(const Point& p, const double eps)
 {
-  if(p.x >= center.x - half_res.x &&
-     p.x <= center.x + half_res.x &&
-     p.y >= center.y - half_res.y &&
-     p.y <= center.y + half_res.y)
+  if(p.x >= center.x - half_res.x - eps &&
+     p.x <= center.x + half_res.x + eps &&
+     p.y >= center.y - half_res.y - eps &&
+     p.y <= center.y + half_res.y + eps)
     return true;
   else
     return false;
@@ -40,7 +40,7 @@ bool BoundingBox::contains(const Point& p)
 
 bool BoundingBox::intersects(const BoundingBox& b)
 {
-  
+
   if(center.x - half_res.x <= b.center.x + b.half_res.x &&
      center.x + half_res.x >= b.center.x - b.half_res.x &&
      center.y - half_res.y <= b.center.y + b.half_res.y &&
@@ -52,25 +52,14 @@ bool BoundingBox::intersects(const BoundingBox& b)
     return false;
 }
 
-QuadTree::QuadTree(const double cx, const double cy, const double range)
+QuadTree::QuadTree(const BoundingBox boundary, const int parent_depth, const double eps)
 {
   MAX_DEPTH = 6;
-  
-  boundary = BoundingBox(Point(cx, cy), Point(range, range));
-  depth = 1;
-  
-  NE = 0;
-  NW = 0;
-  SE = 0;
-  SW = 0;
-}
+  EPSILON = eps;
 
-QuadTree::QuadTree(const BoundingBox boundary, const int parent_depth) : boundary(boundary)
-{
-  MAX_DEPTH = 6;
-  
   depth = parent_depth + 1;
-  
+  this->boundary = boundary;
+
   NE = 0;
   NW = 0;
   SE = 0;
@@ -88,57 +77,60 @@ QuadTree::~QuadTree()
 QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double> y, const double eps = 1.0e-12)
 {
   int n = x.size();
-  
+
   double xmin = x[0];
   double ymin = y[0];
   double xmax = x[0];
   double ymax = y[0];
-  
+
   for(int i = 0 ; i < n ; i++)
   {
-    
     if(x[i] < xmin)
       xmin = x[i];
     else if(x[i] > xmax)
       xmax = x[i];
-    
+
     if(y[i] < ymin)
       ymin = y[i];
     else if(y[i] > ymax)
       ymax = y[i];
   }
-  
+
   double xrange = xmax - xmin;
   double yrange = ymax - ymin;
   double range = xrange > yrange ? xrange/2 : yrange/2;
-  
-  QuadTree *tree = new QuadTree( (xmin+xmax)/2, (ymin+ymax)/2, range + eps);
-  
+
+  Point bcenter((xmin+xmax)/2, (ymin+ymax)/2);
+  Point brange(range, range);
+  BoundingBox bbox(bcenter, brange);
+
+  QuadTree *tree = new QuadTree(bbox, 0, eps);
+
   for(int i = 0 ; i < n ; i++)
   {
     Point p(x[i], y[i], i);
-    if (!tree->insert(p)) {
+
+    if (!tree->insert(p))
       error("Failed to insert point into QuadTree.\nPlease post input to tsearch  (or tsearchn at\nhttps://github.com/davidcsterratt/geometry/issues\nor email the maintainer.");
-    }
   }
-  
+
   return tree;
 }
 
 bool QuadTree::insert(const Point& p)
 {
-  if(!boundary.contains(p))
+  if(!boundary.contains(p, EPSILON))
     return false;
-  
+
   if(depth == MAX_DEPTH)
   {
     points.push_back(p);
     return true;
   }
-  
+
   if(NW == 0)
     subdivide();
-  
+
   if(NW->insert(p))
     return true;
   if(NE->insert(p))
@@ -147,52 +139,51 @@ bool QuadTree::insert(const Point& p)
     return true;
   if(SE->insert(p))
     return true;
-  
+
   return false;
 }
 
 void QuadTree::subdivide()
 {
-  double esp = 1.0e-12;
   double half_res_half = boundary.half_res.x * 0.5;
-  
-  Point p(half_res_half + esp, half_res_half + esp);
+
+  Point p(half_res_half, half_res_half);
   Point pNE(boundary.center.x + half_res_half, boundary.center.y + half_res_half);
   Point pNW(boundary.center.x - half_res_half, boundary.center.y + half_res_half);
   Point pSE(boundary.center.x + half_res_half, boundary.center.y - half_res_half);
   Point pSW(boundary.center.x - half_res_half, boundary.center.y - half_res_half);
-  
-  NE = new QuadTree(BoundingBox(pNE, p), depth);
-  NW = new QuadTree(BoundingBox(pNW, p), depth);
-  SE = new QuadTree(BoundingBox(pSE, p), depth);
-  SW = new QuadTree(BoundingBox(pSW, p), depth);
+
+  NE = new QuadTree(BoundingBox(pNE, p), depth, EPSILON);
+  NW = new QuadTree(BoundingBox(pNW, p), depth, EPSILON);
+  SE = new QuadTree(BoundingBox(pSE, p), depth, EPSILON);
+  SW = new QuadTree(BoundingBox(pSW, p), depth, EPSILON);
 }
 
 void QuadTree::range_lookup(const BoundingBox bb, std::vector<Point*>& res, const int method)
 {
   if(!boundary.intersects(bb))
     return;
-  
+
   if(depth == MAX_DEPTH)
   {
     switch(method)
     {
     case 1: getPointsSquare(bb, points, res);
       break;
-      
+
     case 2: getPointsCircle(bb, points, res);
       break;
     }
   }
-  
+
   if(NW == 0)
     return;
-  
+
   NE->range_lookup(bb, res, method);
   NW->range_lookup(bb, res, method);
   SE->range_lookup(bb, res, method);
   SW->range_lookup(bb, res, method);
-  
+
   return;
 }
 
@@ -234,7 +225,7 @@ bool QuadTree::in_circle(const Point& p1, const Point& p2, const double r)
   double A = p1.x - p2.x;
   double B = p1.y - p2.y;
   double d = sqrt(A*A + B*B);
-  
+
   return(d <= r);
 }
 
@@ -244,6 +235,6 @@ bool QuadTree::in_rect(const BoundingBox& bb, const Point& p)
   double B = bb.center.y - p.y;
   A = A < 0 ? -A : A;
   B = B < 0 ? -B : B;
-  
+
   return(A <= bb.half_res.x && B <= bb.half_res.y);
 }

--- a/pkg/src/QuadTree.h
+++ b/pkg/src/QuadTree.h
@@ -24,7 +24,7 @@ struct Point
 {
   double x, y;
   int id;
-  
+
   Point();
   Point(const double, const double);
   Point(const double, const double, const int);
@@ -33,26 +33,26 @@ struct Point
 struct BoundingBox
 {
   Point center, half_res;
-  
+
   BoundingBox();
   BoundingBox(const Point,const Point);
-  bool contains(const Point&);
+  bool contains(const Point&, const double);
   bool intersects(const BoundingBox&);
 };
 
 class QuadTree
 {
 public:
-  QuadTree(const double, const double, const double);
   ~QuadTree();
   static QuadTree* create(const std::vector<double>, const std::vector<double>, const double eps);
   bool insert(const Point&);
   void rect_lookup(const double, const double, const double, const double, std::vector<Point*>&);
   void circle_lookup(const double, const double, const double, std::vector<Point*>&);
-  
-  
+
+
 private:
   int MAX_DEPTH;
+  double EPSILON;
   int depth;
   BoundingBox boundary;
   std::vector<Point> points;
@@ -60,9 +60,9 @@ private:
   QuadTree* NW;
   QuadTree* SE;
   QuadTree* SW;
-  
-  QuadTree(const BoundingBox, const int);
-  
+
+  QuadTree(const BoundingBox, const int, const double);
+
   void subdivide();
   void range_lookup(const BoundingBox, std::vector<Point*>&, const int);
   void getPointsSquare(const BoundingBox, std::vector<Point>&, std::vector<Point*>&);


### PR DESCRIPTION
Ok this fix is more elegant:

1. I removed a constructor. This is not related to the bug but this contructor was not very useful. Less code, less errors...
2. I don't buffer the quad regions anymore. This was ok for the level 1 but a bit dirty for next levels because it creates overlapping quad regions.
3. Instead I added a tolerance into `BoundingBox::contains()` similarly to the tolerance in `pointInTriangle()`
4. The tolerance is propagated through the QuadTree constructors so you can change the value and expose this options to the user.

This fix passes all your tests and all my own test in my package. In my own package I first removed the previous tolerance and I added and error when insertion fails as you did. This generated many errors because my QuadTree is intensively used for point cloud processing. Then I fixed back the issue by moving the tolerance into  `BoundingBox::contains()` and everything was ok. So I'm confident on the fix.
