### PR TITLE
Update tests for testthat v3 compatibility

### DIFF
--- a/pkg/tests/testthat/test-convhulln.R
+++ b/pkg/tests/testthat/test-convhulln.R
@@ -74,10 +74,10 @@ test_that("convhulln can run on an example with 3000 points", {
   ps <- matrix(rnorm(3000), ncol=3)
   ps <- sqrt(3)*ps/drop(sqrt((ps^2) %*% rep(1,3)))
   ts <- convhulln(ps)
-  expect_that(nrow(ts), equals(1996))
+  expect_identical(nrow(ts), 1996L)
   ts.full <- convhulln(ps, "FA")
-  expect_that(ts.full$area, equals(37.47065, tolerance=0.001))
-  expect_that(ts.full$vol, equals(21.50165, tolerance=0.001))
+  expect_equal(ts.full$area, 37.47065, tolerance=0.001)
+  expect_equal(ts.full$vol, 21.50165, tolerance=0.001)
 })
 
 test_that("convhulln throws an error with duplicated points", {
@@ -93,7 +93,7 @@ test_that("If the input matrix contains NAs, convhulln should return an error", 
   expect_error(convhulln(ps))
 })
 
-test_that("If there are not enough points to construct a simplex, an error is thrown", {         
+test_that("If there are not enough points to construct a simplex, an error is thrown", {
   expect_error(convhulln(diag(4)))
 })
 
@@ -109,14 +109,14 @@ test_that("Output to file works", {
 })
 
 test_that("Output of non-triangulated facets works", {
-  X1 <- matrix(c( 1,  1,  1, 
+  X1 <- matrix(c( 1,  1,  1,
                   1,  1, -1,
                   1, -1,  1,
                   1, -1, -1,
                  -1,  1,  1,
                  -1,  1, -1,
                  -1, -1,  1,
-                 -1, -1, -1, 
+                 -1, -1, -1,
                   3,  0,  0), ncol=3, byrow = TRUE)
   ts1 <- convhulln(X1, return.non.triangulated.facets = TRUE)
   tbl1 <- table(rowSums(!is.na(ts1)))

--- a/pkg/tests/testthat/test-delaunayn.R
+++ b/pkg/tests/testthat/test-delaunayn.R
@@ -8,7 +8,8 @@ test_that("delaunayn produces the correct output", {
                                     data.frame(b=c(-1, 1))),
                               data.frame(d=c(-1, 1)))))
   ts <- delaunayn(ps)
-  expect_is(ts, "matrix")
+  expect_type(ts, "integer")
+  expect_identical(dim(ts), c(12L, 4L))
 
   ## With output.options=TRUE, there should be a trinagulation, areas and
   ## neighbours and the sum of the ares should be 8
@@ -17,7 +18,7 @@ test_that("delaunayn produces the correct output", {
   expect_equal(length(ts.full$areas), nrow(ts.full$tri))
   expect_equal(length(ts.full$neighbours), nrow(ts.full$tri))
   expect_equal(sum(ts.full$area), 8)
-  
+
   ## With full output, there should be a trinagulation, areas and
   ## neighbours and the sum of the ares should be 8
   ## full will be deprecated in a future version
@@ -26,8 +27,8 @@ test_that("delaunayn produces the correct output", {
   expect_equal(length(ts.full$areas), nrow(ts.full$tri))
   expect_equal(length(ts.full$neighbours), nrow(ts.full$tri))
   expect_equal(sum(ts.full$area), 8)
-  
-  ## tsearchn shouldn't return a "degnerate simplex" error. 
+
+  ## tsearchn shouldn't return a "degnerate simplex" error.
   expect_silent(tsearchn(ps, ts, cbind(1, 2, 4)))
 
   ## If the input matrix contains NAs, delaunayn should return an error
@@ -39,13 +40,13 @@ test_that("delaunayn produces the correct output", {
 test_that("In the case of just one triangle, delaunayn returns a matrix", {
   pc  <- rbind(c(0, 0), c(0, 1), c(1, 0))
   pct <- delaunayn(pc)
-  expect_is(pct, "matrix")
-  expect_equal(nrow(pct), 1)
+  expect_type(pct, "integer")
+  expect_identical(dim(pct), c(1L, 3L))
   ## With no options it should also produce a triangulation. This
   ## mirrors the behaviour of octave and matlab
   pct <- delaunayn(pc, "")
-  expect_is(pct, "matrix")
-  expect_equal(nrow(pct), 1)
+  expect_type(pct, "integer")
+  expect_identical(dim(pct), c(1L, 3L))
 
   pct.full <- delaunayn(pc, output.options=TRUE)
   expect_equal(pct.full$areas, 0.5)
@@ -54,8 +55,8 @@ test_that("In the case of just one triangle, delaunayn returns a matrix", {
 test_that("In the case of a degenerate triangle, delaunayn returns a matrix with zero rows", {
   pc  <- rbind(c(0, 0), c(0, 1), c(0, 2))
   pct <- delaunayn(pc)
-  expect_is(pct, "matrix")
-  expect_equal(nrow(pct), 0)
+  expect_type(pct, "integer")
+  expect_identical(dim(pct), c(0L, 3L))
   pct.full <- delaunayn(pc, output.options=TRUE)
   expect_equal(length(pct.full$areas), 0)
   expect_equal(length(pct.full$neighbours), 0)
@@ -64,8 +65,8 @@ test_that("In the case of a degenerate triangle, delaunayn returns a matrix with
 test_that("In the case of just one tetrahaedron, delaunayn returns a matrix", {
   pc  <- rbind(c(0, 0, 0), c(0, 1, 0), c(1, 0, 0), c(0, 0, 1))
   pct <- delaunayn(pc)
-  expect_is(pct, "matrix")
-  expect_equal(nrow(pct), 1)
+  expect_type(pct, "integer")
+  expect_identical(dim(pct), c(1L, 4L))
   pct.full <- delaunayn(pc, output.options=TRUE)
    expect_equal(pct.full$areas, 1/6)
 })

--- a/pkg/tests/testthat/test-inhulln.R
+++ b/pkg/tests/testthat/test-inhulln.R
@@ -7,23 +7,23 @@ test_that("inhulln gives the expected output", {
   ch <- convhulln(p)
   ## Should be in hull
   pin <- inhulln(ch, cbind(-0.5, -0.5))
-  expect_that(pin, equals(TRUE))
+  expect_true(pin)
   ## Should be outside hull
   pout <- inhulln(ch, cbind(1, 1))
-  expect_that(pout, equals(FALSE))
+  expect_false(pout)
 
   ## Erroneous input is caught safely
   expect_error(inhulln(1, 2), "Convex hull has no convhulln attribute")
   expect_error(inhulln(ch, rbind(1, 1)), "Number of columns in test points p (1) not equal to dimension of hull (2).", fixed=TRUE)
   expect_error(inhulln(ch, cbind(1, 1, 1)), "Number of columns in test points p (3) not equal to dimension of hull (2).", fixed=TRUE)
-  
+
   ## Test cube
   p <- rbox(n=0, D=3, C=1)
   ch <- convhulln(p)
   tp <-  cbind(seq(-1.9, 1.9, by=0.2), 0, 0)
   pin <- inhulln(ch, tp)
   ## Points on x-axis should be in box only between -1 and 1
-  expect_that(pin, equals(tp[,1] < 1 & tp[,1] > -1))
+  expect_equal(pin, tp[,1] < 1 & tp[,1] > -1)
 
   ## Test hypercube
   p <- rbox(n=0, D=4, C=1)
@@ -31,6 +31,6 @@ test_that("inhulln gives the expected output", {
   tp <-  cbind(seq(-1.9, 1.9, by=0.2), 0, 0, 0)
   pin <- inhulln(ch, tp)
   ## Points on x-axis should be in box only between -1 and 1
-  expect_that(pin, equals(tp[,1] < 1 & tp[,1] > -1))
+  expect_equal(pin, tp[,1] < 1 & tp[,1] > -1)
 
 })

--- a/pkg/tests/testthat/test-parallel.R
+++ b/pkg/tests/testthat/test-parallel.R
@@ -12,11 +12,11 @@ test_that("delaunayn can be called with mc.apply", {
   N <- 100000
   P <- matrix(runif(2*N), N, 2)
   T <- delaunayn(P)
-  expect_that(nrow(T), equals(199966))
+  expect_identical(nrow(T), 199966L)
 
-  ## Now try out the parallel version. 
+  ## Now try out the parallel version.
   Ts <- mclapply(list(P, P, P, P), delaunayn, mc.cores=mc.cores)
-  expect_that(length(Ts), equals(4))
-  expect_that(nrow(Ts[[1]]), equals(199966))
-  expect_that(Ts[[1]], equals(T))
+  expect_length(Ts, 4)
+  expect_identical(nrow(Ts[[1]]), 199966L)
+  expect_identical(Ts[[1]], T)
 })

--- a/pkg/tests/testthat/test-polyarea.R
+++ b/pkg/tests/testthat/test-polyarea.R
@@ -3,7 +3,7 @@ test_that("ployarea computes the area of two identical squares", {
   x <- c(1, 1, 3, 3, 1)
   y <- c(1, 3, 3, 1, 1)
 
-  expect_that(polyarea(cbind(x, x), cbind(y, y)), equals(c(4, 4)))
-  expect_that(polyarea(cbind(x, x), cbind(y, y), 1), equals(c(4, 4)))
-  expect_that(polyarea(rbind(x, x), rbind(y, y), 2), equals(c(4, 4)))
+  expect_equal(polyarea(cbind(x, x), cbind(y, y)), c(4, 4))
+  expect_equal(polyarea(cbind(x, x), cbind(y, y), 1), c(4, 4))
+  expect_equal(polyarea(rbind(x, x), rbind(y, y), 2), c(4, 4))
 })

--- a/pkg/tests/testthat/test-tsearch-tsearchn-comparison.R
+++ b/pkg/tests/testthat/test-tsearch-tsearchn-comparison.R
@@ -9,9 +9,9 @@ test_that("tsearch and tsearchn give the same results", {
 
   out <- tsearch(X, Y, T, XI, YI)
   outn <- tsearchn(cbind(X, Y), T, cbind(XI, YI), fast=FALSE)
-  
-  expect_that(na.omit(out), equals(na.omit(outn$idx)))
+
+  expect_equal(na.omit(out), na.omit(outn$idx))
 
   out <- tsearch(X, Y, T, XI, YI, TRUE)
-  expect_that(na.omit(outn$p), equals(na.omit(out$p), tolerance=1e-12))
+  expect_equal(na.omit(outn$p), na.omit(out$p), tolerance=1e-12)
 })

--- a/pkg/tests/testthat/test-tsearch.R
+++ b/pkg/tests/testthat/test-tsearch.R
@@ -6,16 +6,16 @@ test_that("tsearch gives the expected output", {
   tri <- matrix(c(1, 2, 3), 1, 3)
   ## Should be in triangle #1
   ts <- tsearch(x, y, tri, -1, -1)
-  expect_that(ts, equals(1))
+  expect_equal(ts, 1)
   ## Should be in triangle #1
   ts <- tsearch(x, y, tri, 1, -1)
-  expect_that(ts, equals(1))
+  expect_equal(ts, 1)
   ## Should be in triangle #1
   ts <- tsearch(x, y, tri, -1, 1)
-  expect_that(ts, equals(1))
+  expect_equal(ts, 1)
   ## Centroid
   ts <- tsearch(x, y, tri, -1/3, -1/3)
-  expect_that(ts, equals(1))
+  expect_equal(ts, 1)
   ## Should be outside triangle #1, so should return NA
   ts <- tsearch(x, y, tri, 1, 1)
   expect_true(is.na(ts))
@@ -55,7 +55,7 @@ test_that("tsearch can deal with faulty input", {
   ps <- matrix(0, 0, 2)
   expect_equal(tsearch(x, y, tri, ps[,1], ps[,2], bary=TRUE),
                list(idx=integer(0), p=matrix(0, 0, 3)))
-  
+
 })
 
 ## See
@@ -63,84 +63,84 @@ test_that("tsearch can deal with faulty input", {
 ## for inspiration for the test below
 
 test_that("tsearch gives the expected output when computer precision problem arise", {
-  
+
   # ==== Hand made test ====
-  
+
   x1 <- 1/10
   y1 <- 1/9
   x2 <- 100/8
   y2 <- 100/3
   P <- rbind(c(x1, y1),  c(x2, y2),  c(100/4, 100/9), c(-100/8, 100/6))
-  
+
   # And a single point p(x, y) lying exactly on the segment [p1, p2] :
   xi <- x1 + (3/7)*(x2 - x1)
   yi <- y1 + (3/7)*(y2 - y1)
-  
+
   # Should always give triangle 2 since this is the lastest tested
-  
+
   tri1 <- rbind(1:3, c(1, 2, 4))
   ts <- tsearch(P[,1], P[,2], tri1, xi, yi)
   expect_equal(ts, 2)
-  
+
   tri2 <- rbind(c(1, 2, 4), 1:3)
   ts <- tsearch(P[,1], P[,2], tri2, xi, yi)
   expect_equal(ts, 2)
-  
+
   # The same but with only one triangle
   P <- rbind(c(x1, y1),  c(x2, y2),  c(100/4, 100/9))
   tri <- matrix(c(1, 2, 3), 1, 3)
   ts <- tsearch(P[,1], P[,2], tri, xi, yi)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   tri <- matrix(c(3, 2, 1), 1, 3)
   ts <- tsearch(P[,1], P[,2], tri, xi, yi)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   # The same but with the other triangle
   P <- rbind(c(x2, y2),  c(100/4, 100/9), c(-100/8, 100/6))
   tri <- matrix(c(1, 2, 3), 1, 3)
   ts <- tsearch(P[,1], P[,2], tri, xi, yi)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   tri <- matrix(c(3, 2, 1), 1, 3)
   ts <- tsearch(P[,1], P[,2], tri, xi, yi)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   # Another test
   x <- c(6.89, 7.15, 7.03)
   y <- c(7.76, 7.75, 8.35)
   tri <- matrix(c(1, 2, 3), 1, 3)
   ts <- tsearch(x, y, tri, 7.125, 7.875)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   # ==== Test known to bug in former code ====
-  
+
   x <- c(278287.03, 278286.89, 278287.15, 278287.3)
   y <- c(602248.35, 602247.76, 602247.75, 602248.35)
-  
+
   xi = 278287.125
-  yi = 602247.875  
-  
+  yi = 602247.875
+
   # Should always give triangle 2 but here it does not work
-  
+
   tri = rbind(c(3,1,4), c(3,1,2))
   ts <- tsearch(x, y, tri, xi, yi)
-  expect_that(ts, equals(2))
-  
+  expect_equal(ts, 2)
+
   tri = rbind(c(1,2,3), c(1,3,4))
   ts <- tsearch(x, y, tri, xi, yi)
-  expect_that(ts, equals(1))
-  
+  expect_equal(ts, 1)
+
   # This is because the buffer epsilon is 1.0e-12.
-  
+
   x <- c(278287.03, 278287.15, 278287.3)
   y <- c(602248.35, 602247.75, 602248.35)
-  
+
   tri <- matrix(c(1, 2, 3), 1, 3)
   ts <- tsearch(x, y, tri, xi, yi)
   expect_true(is.na(ts))
-  
-  #expect_that(ts, equals(1)))  #With epsilon = 1.0e-10 it works.
+
+  #expect_equal(ts, 1)  #With epsilon = 1.0e-10 it works.
 })
 
 test_that("no regression on Issue #39", {


### PR DESCRIPTION
Release notes for the upcoming testthat version are here: https://github.com/r-lib/testthat/blob/master/NEWS.md

In particular, two functions are deprecated:
- `expect_that()`
- `expect_is()`. There is no direct equivalence for the tests you were doing so I split this in two tests: `expect_type(..., "integer")` et `expect_dim()`