### PR TITLE
Reorder documentation lines

### DIFF
--- a/pkg/R/cart2sph.R
+++ b/pkg/R/cart2sph.R
@@ -18,10 +18,11 @@
 
 ## This file has been adapted for R by David C Sterratt
 
-##' If called with a single matrix argument then each row of \code{c} 
-##' represents the Cartesian coordinate (\code{x}, \code{y}, \code{z}).
-##' 
 ##' Transform Cartesian to spherical coordinates
+##'
+##' If called with a single matrix argument then each row of \code{c}
+##' represents the Cartesian coordinate (\code{x}, \code{y}, \code{z}).
+##'
 ##' @param x x-coordinates or matrix with three columns
 ##' @param y y-coordinates (optional, if \code{x}) is a matrix 
 ##' @param z z-coordinates (optional, if \code{x}) is a matrix 

--- a/pkg/man/cart2sph.Rd
+++ b/pkg/man/cart2sph.Rd
@@ -2,8 +2,7 @@
 % Please edit documentation in R/cart2sph.R
 \name{cart2sph}
 \alias{cart2sph}
-\title{If called with a single matrix argument then each row of \code{c} 
-represents the Cartesian coordinate (\code{x}, \code{y}, \code{z}).}
+\title{Transform Cartesian to spherical coordinates}
 \usage{
 cart2sph(x, y = NULL, z = NULL)
 }
@@ -21,7 +20,8 @@ Matrix with columns:
 \item{\code{r}}{the distance to the origin \code{(0, 0, 0)}}
 }
 \description{
-Transform Cartesian to spherical coordinates
+If called with a single matrix argument then each row of \code{c}
+represents the Cartesian coordinate (\code{x}, \code{y}, \code{z}).
 }
 \seealso{
 \code{\link{sph2cart}}, \code{\link{cart2pol}},


### PR DESCRIPTION
It looks like these two lines have been swapped in the roxygen comment, which results in a confusing title in the final `Rd` file.