### PR TITLE
Replace rgl.* with *3d

### DIFF
--- a/pkg/DESCRIPTION
+++ b/pkg/DESCRIPTION
@@ -41,4 +41,4 @@ LinkingTo:
     RcppProgress
 Encoding: UTF-8
 Language: en-GB
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3

--- a/pkg/R/convhulln.R
+++ b/pkg/R/convhulln.R
@@ -76,8 +76,8 @@
 ##' ps <- sqrt(3)*ps/drop(sqrt((ps^2) %*% rep(1, 3)))
 ##' ts.surf <- t(convhulln(ps))  # see the qhull documentations for the options
 ##' \dontrun{
-##' rgl.triangles(ps[ts.surf,1],ps[ts.surf,2],ps[ts.surf,3],col="blue",alpha=.2)
-##' for(i in 1:(8*360)) rgl.viewpoint(i/8)
+##' rgl::triangles3d(ps[ts.surf,1],ps[ts.surf,2],ps[ts.surf,3],col="blue",alpha=.2)
+##' for(i in 1:(8*360)) rgl::view3d(i/8)
 ##' }
 ##'
 ##' ## Square
@@ -164,9 +164,9 @@ plot.convhulln <- function(x, y, ...) {
   if (ncol(x$p) == 3) {
     if(requireNamespace("rgl") == FALSE)
       stop("The rgl package is required for tetramesh")
-    if (!add) rgl::rgl.clear()
+    if (!add) rgl::clear3d()
     if (ncol(x$hull) == 3) {
-      do.call(rgl::rgl.triangles,
+      do.call(rgl::triangles3d,
               c(list(x$p[t(x$hull),1], x$p[t(x$hull),2], x$p[t(x$hull),3]),
                 args))
     } else {

--- a/pkg/R/delaunayn.R
+++ b/pkg/R/delaunayn.R
@@ -93,8 +93,8 @@
 ##' 
 ##' # example tetramesh
 ##' \dontrun{
-##' rgl::rgl.viewpoint(60)
-##' rgl::rgl.light(120,60)
+##' rgl::view3d(60)
+##' rgl::light3d(120,60)
 ##' tetramesh(tc,pc, alpha=0.9)
 ##' }
 ##'

--- a/pkg/R/surf.tri.R
+++ b/pkg/R/surf.tri.R
@@ -38,15 +38,15 @@
 ##' tbr = t(surf.tri(brain, delaunayn(brain)))
 ##' tsk = t(surf.tri(skull, delaunayn(skull)))
 ##' tsc = t(surf.tri(scalp, delaunayn(scalp)))
-##' rgl::rgl.triangles(brain[tbr,1], brain[tbr,2], brain[tbr,3],col="gray")
-##' rgl::rgl.triangles(skull[tsk,1], skull[tsk,2], skull[tsk,3],col="white", alpha=0.3)
-##' rgl::rgl.triangles(scalp[tsc,1], scalp[tsc,2], scalp[tsc,3],col="#a53900", alpha=0.6)
-##' rgl::rgl.viewpoint(-40,30,.4,zoom=.03)
+##' rgl::triangles3d(brain[tbr,1], brain[tbr,2], brain[tbr,3],col="gray")
+##' rgl::triangles3d(skull[tsk,1], skull[tsk,2], skull[tsk,3],col="white", alpha=0.3)
+##' rgl::triangles3d(scalp[tsc,1], scalp[tsc,2], scalp[tsc,3],col="#a53900", alpha=0.6)
+##' rgl::view3d(-40,30,.4,zoom=.03)
 ##' lx = c(-.025,.025); ly = -c(.02,.02);
-##' rgl::rgl.spheres(elec[,1],elec[,3],elec[,2],radius=.0025,col='gray')
-##' rgl::rgl.spheres( lx, ly,.11,radius=.015,col="white")
-##' rgl::rgl.spheres( lx, ly,.116,radius=.015*.7,col="brown")
-##' rgl::rgl.spheres( lx, ly,.124,radius=.015*.25,col="black")
+##' rgl::spheres3d(elec[,1],elec[,3],elec[,2],radius=.0025,col='gray')
+##' rgl::spheres3d( lx, ly,.11,radius=.015,col="white")
+##' rgl::spheres3d( lx, ly,.116,radius=.015*.7,col="brown")
+##' rgl::spheres3d( lx, ly,.124,radius=.015*.25,col="black")
 ##' }
 ##'
 ##' @export

--- a/pkg/R/tetramesh.R
+++ b/pkg/R/tetramesh.R
@@ -26,8 +26,8 @@
 ##' 
 ##' # example tetramesh
 ##' clr = rep(1,3) %o% (1:nrow(tc)+1)
-##' rgl::rgl.viewpoint(60,fov=20)
-##' rgl::rgl.light(270,60)
+##' rgl::view3d(60,fov=20)
+##' rgl::light3d(270,60)
 ##' tetramesh(tc,pc,alpha=0.7,col=clr)
 ##' }
 ##' @export
@@ -42,8 +42,8 @@ tetramesh <- function (T, X, col = grDevices::heat.colors(nrow(T)), clear = TRUE
     stop("Expect second arg `X' to have 3 columns.")
   t = t(rbind(T[, -1], T[, -2], T[, -3], T[, -4]))
   if (clear)
-    rgl::rgl.clear()
-  rgl::rgl.triangles(X[t, 1], X[t, 2], X[t, 3], col = col, ...)
+    rgl::clear3d()
+  rgl::triangles3d(X[t, 1], X[t, 2], X[t, 3], col = col, ...)
 }
 
 

--- a/pkg/man/convhulln.Rd
+++ b/pkg/man/convhulln.Rd
@@ -81,8 +81,8 @@ ps <- matrix(rnorm(3000), ncol=3)
 ps <- sqrt(3)*ps/drop(sqrt((ps^2) \%*\% rep(1, 3)))
 ts.surf <- t(convhulln(ps))  # see the qhull documentations for the options
 \dontrun{
-rgl.triangles(ps[ts.surf,1],ps[ts.surf,2],ps[ts.surf,3],col="blue",alpha=.2)
-for(i in 1:(8*360)) rgl.viewpoint(i/8)
+rgl::triangles3d(ps[ts.surf,1],ps[ts.surf,2],ps[ts.surf,3],col="blue",alpha=.2)
+for(i in 1:(8*360)) rgl::view3d(i/8)
 }
 
 ## Square

--- a/pkg/man/delaunayn.Rd
+++ b/pkg/man/delaunayn.Rd
@@ -94,8 +94,8 @@ tc <- delaunayn(pc)
 
 # example tetramesh
 \dontrun{
-rgl::rgl.viewpoint(60)
-rgl::rgl.light(120,60)
+rgl::view3d(60)
+rgl::light3d(120,60)
 tetramesh(tc,pc, alpha=0.9)
 }
 

--- a/pkg/man/surf.tri.Rd
+++ b/pkg/man/surf.tri.Rd
@@ -49,15 +49,15 @@ skull = meshdata$mesh.skull[,c(1,3,2)]
 tbr = t(surf.tri(brain, delaunayn(brain)))
 tsk = t(surf.tri(skull, delaunayn(skull)))
 tsc = t(surf.tri(scalp, delaunayn(scalp)))
-rgl::rgl.triangles(brain[tbr,1], brain[tbr,2], brain[tbr,3],col="gray")
-rgl::rgl.triangles(skull[tsk,1], skull[tsk,2], skull[tsk,3],col="white", alpha=0.3)
-rgl::rgl.triangles(scalp[tsc,1], scalp[tsc,2], scalp[tsc,3],col="#a53900", alpha=0.6)
-rgl::rgl.viewpoint(-40,30,.4,zoom=.03)
+rgl::triangles3d(brain[tbr,1], brain[tbr,2], brain[tbr,3],col="gray")
+rgl::triangles3d(skull[tsk,1], skull[tsk,2], skull[tsk,3],col="white", alpha=0.3)
+rgl::triangles3d(scalp[tsc,1], scalp[tsc,2], scalp[tsc,3],col="#a53900", alpha=0.6)
+rgl::view3d(-40,30,.4,zoom=.03)
 lx = c(-.025,.025); ly = -c(.02,.02);
-rgl::rgl.spheres(elec[,1],elec[,3],elec[,2],radius=.0025,col='gray')
-rgl::rgl.spheres( lx, ly,.11,radius=.015,col="white")
-rgl::rgl.spheres( lx, ly,.116,radius=.015*.7,col="brown")
-rgl::rgl.spheres( lx, ly,.124,radius=.015*.25,col="black")
+rgl::spheres3d(elec[,1],elec[,3],elec[,2],radius=.0025,col='gray')
+rgl::spheres3d( lx, ly,.11,radius=.015,col="white")
+rgl::spheres3d( lx, ly,.116,radius=.015*.7,col="brown")
+rgl::spheres3d( lx, ly,.124,radius=.015*.25,col="black")
 }
 
 }

--- a/pkg/man/tetramesh.Rd
+++ b/pkg/man/tetramesh.Rd
@@ -36,8 +36,8 @@ tc = delaunayn(pc)
 
 # example tetramesh
 clr = rep(1,3) \%o\% (1:nrow(tc)+1)
-rgl::rgl.viewpoint(60,fov=20)
-rgl::rgl.light(270,60)
+rgl::view3d(60,fov=20)
+rgl::light3d(270,60)
 tetramesh(tc,pc,alpha=0.7,col=clr)
 }
 }


### PR DESCRIPTION
An upcoming release of the rgl package will deprecate the rgl.* functions, which will lead to warnings when you call them.  This PR replaces them with equivalent *3d functions.

The main change in the display will be the background colour; if you prefer the original, you can specify it explicitly.  See  https://github.com/dmurdoch/rgl/blob/deprecated/vignettes/deprecation.Rmd for details.