### PR TITLE
Fix #71 noRemap

### DIFF
--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -15,7 +15,6 @@
 // Author: Jean-Romain Roussel
 // 3 may 2017: copy from package lidR to package geometry by Jean-Romain Roussel to operate in fast tsearch funtion
 
-#include <R.h>
 #include "QuadTree.h"
 #include <cmath>
 #include <limits>
@@ -111,7 +110,7 @@ QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double
     Point p(x[i], y[i], i);
 
     if (!tree->insert(p))
-      error("Failed to insert point into QuadTree.\nPlease post input to tsearch  (or tsearchn at\nhttps://github.com/davidcsterratt/geometry/issues\nor email the maintainer.");
+      return nullptr;
   }
 
   return tree;

--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -110,7 +110,10 @@ QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double
     Point p(x[i], y[i], i);
 
     if (!tree->insert(p))
+    {
+      delete tree;
       return nullptr;
+    }
   }
 
   return tree;


### PR DESCRIPTION
This should fix the `noRemap` as well a a memory leak. `error()`  creates a `longjmp` and memory is not desalocated since the destructor of the quatree is not called. `error()` is no longer used. I'm using `Rcpp::stop()` instead which should deal internally with the annoying and constantly changing `REMAP` CRAN policy. I've not tested against R-devel.