### PR TITLE
Fix #57

### DIFF
--- a/pkg/src/QuadTree.cpp
+++ b/pkg/src/QuadTree.cpp
@@ -73,7 +73,7 @@ QuadTree::~QuadTree()
   delete SW;
 }
 
-QuadTree* QuadTree::create(const std::vector<double> x, const std::vector<double> y, const double eps = 1.0e-12)
+QuadTree* QuadTree::create(const std::vector<double>& x, const std::vector<double>& y, const double eps = 1.0e-12)
 {
   int n = x.size();
 

--- a/pkg/src/QuadTree.h
+++ b/pkg/src/QuadTree.h
@@ -44,7 +44,7 @@ class QuadTree
 {
 public:
   ~QuadTree();
-  static QuadTree* create(const std::vector<double>, const std::vector<double>, const double eps);
+  static QuadTree* create(const std::vector<double>&, const std::vector<double>&, const double eps);
   bool insert(const Point&);
   void rect_lookup(const double, const double, const double, const double, std::vector<Point*>&);
   void circle_lookup(const double, const double, const double, std::vector<Point*>&);

--- a/pkg/src/Rtsearch.cpp
+++ b/pkg/src/Rtsearch.cpp
@@ -58,7 +58,18 @@ bool PointInTriangle(Point p0, Point p1, Point p2, Point p, Point* bary, double 
 // [[Rcpp::export]]
 SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVector xi, NumericVector yi, bool bary = false, double eps = 1.0e-12)
 {
-  QuadTree *tree = QuadTree::create(as< std::vector<double> >(xi),as< std::vector<double> >(yi), eps);
+  std::vector<double> xx = as< std::vector<double> >(xi);
+  std::vector<double> yy = as< std::vector<double> >(yi);
+
+  // Compute the minimum of each vector
+  double xoffset = *std::min_element(xx.begin(), xx.end());
+  double yoffset = *std::min_element(yy.begin(), yy.end());
+
+  // Subtract the minimum from all elements in the vector
+  std::transform(xx.begin(), xx.end(), xx.begin(), [xoffset](double& elem) { return elem - xoffset; });
+  std::transform(yy.begin(), yy.end(), yy.begin(), [yoffset](double& elem) { return elem - yoffset; });
+
+  QuadTree *tree = QuadTree::create(xx, yy, eps);
 
   if (tree == nullptr)
     Rcpp::stop("Failed to insert point into QuadTree.\nPlease post input to tsearch  (or tsearchn at\nhttps://github.com/davidcsterratt/geometry/issues\nor email the maintainer.");
@@ -97,9 +108,9 @@ SEXP C_tsearch(NumericVector x,  NumericVector y, IntegerMatrix elem, NumericVec
     int iB = elem(k, 1) - 1;
     int iC = elem(k, 2) - 1;
 
-    Point A(x(iA), y(iA));
-    Point B(x(iB), y(iB));
-    Point C(x(iC), y(iC));
+    Point A(x(iA)-xoffset, y(iA)-yoffset);
+    Point B(x(iB)-xoffset, y(iB)-yoffset);
+    Point C(x(iC)-xoffset, y(iC)-yoffset);
 
     // Boundingbox of A B C
 


### PR DESCRIPTION
What I did simply, is to offset the data close to 0 to gain precision. When working with geographic coordinates like in the reported bug we gain a lot of accuracy.

```r
source("~/Téléchargements/BugData.txt")
library(geometry)
packageVersion("geometry")
dn <- delaunayn(eval.df[, c("XCoord", "YCoord")], options = "")

tri <- tsearch(eval.df[, "XCoord"], eval.df[, "YCoord"], dn, predred.df[, "XCoord"], predred.df[, "YCoord"], bary = T)
tri2 <- tsearch(eval.df[, "XCoord"], eval.df[, "YCoord"], dn, predred.df[, "XCoord"], predred.df[, "YCoord"], bary = T, method = "orig")

all.equal(tri, tri2)
#> TRUE
```
Unit tests are passing